### PR TITLE
move calculations of columns indices and their non repeating mapping

### DIFF
--- a/src/unit_tests/tests_worker.cc
+++ b/src/unit_tests/tests_worker.cc
@@ -6,33 +6,6 @@
 #include <arrow-glib/arrow-glib.h>
 
 
-TEST(WorkerTests, CalculateNewColumnIndices_UniqueColumns) {
-    gint old_column_indices[] = {1, 2, 3};
-    int new_column_indices[3];
-    worker_calculate_new_column_indices(new_column_indices, old_column_indices, 3);
-
-    EXPECT_EQ(new_column_indices[0], 0);
-    EXPECT_EQ(new_column_indices[1], 1);
-    EXPECT_EQ(new_column_indices[2], 2);
-}
-
-TEST(WorkerTests, CalculateNewColumnIndices_RepeatedColumns) {
-    gint old_column_indices[] = {1, 2, 1};
-    int new_column_indices[3];
-    worker_calculate_new_column_indices(new_column_indices, old_column_indices, 3);
-
-    EXPECT_EQ(new_column_indices[0], 0);
-    EXPECT_EQ(new_column_indices[1], 1);
-    EXPECT_EQ(new_column_indices[2], 0);
-}
-
-TEST(WorkerTests, CalculateNewColumnIndices_EmptyInput) {
-    gint old_column_indices[] = {};
-    int new_column_indices[0];
-    worker_calculate_new_column_indices(new_column_indices, old_column_indices, 0);
-
-    SUCCEED();
-}
 //
 // TEST(WorkerTests, ConstructGroupingString) {
 //     GArrowArray* grouping_arrays[2];

--- a/src/unit_tests/tests_worker_group.cc
+++ b/src/unit_tests/tests_worker_group.cc
@@ -78,10 +78,9 @@ TEST(WorkerGroupTests, GetColumnsIndices) {
     request.select[0] = (Select*)malloc(sizeof(Select));
     request.select[0]->column = strdup("column2");
 
-    int grouping_indices[1];
-    int select_indices[1];
+    int columns_indices[2];
 
-    worker_group_get_columns_indices(&request, grouping_indices, select_indices, &error_info);
+    worker_group_get_columns_indices(&request, columns_indices, &error_info);
     EXPECT_NE(error_info.error_code, NO_ERROR);
 
     free(request.group_columns[0]);
@@ -126,5 +125,33 @@ TEST(WorkerGroupTests, GetThreadData_NullRequest) {
 
 TEST(WorkerGroupTests, FreeThreadData_NullInput) {
     worker_group_free_thread_data(nullptr);
+    SUCCEED();
+}
+
+TEST(WorkerTests, CalculateNewColumnIndices_UniqueColumns) {
+    gint old_column_indices[] = {1, 2, 3};
+    int new_column_indices[3];
+    worker_group_calculate_new_column_indices(new_column_indices, old_column_indices, 3);
+
+    EXPECT_EQ(new_column_indices[0], 0);
+    EXPECT_EQ(new_column_indices[1], 1);
+    EXPECT_EQ(new_column_indices[2], 2);
+}
+
+TEST(WorkerTests, CalculateNewColumnIndices_RepeatedColumns) {
+    gint old_column_indices[] = {1, 2, 1};
+    int new_column_indices[3];
+    worker_group_calculate_new_column_indices(new_column_indices, old_column_indices, 3);
+
+    EXPECT_EQ(new_column_indices[0], 0);
+    EXPECT_EQ(new_column_indices[1], 1);
+    EXPECT_EQ(new_column_indices[2], 0);
+}
+
+TEST(WorkerTests, CalculateNewColumnIndices_EmptyInput) {
+    gint old_column_indices[] = {};
+    int new_column_indices[0];
+    worker_group_calculate_new_column_indices(new_column_indices, old_column_indices, 0);
+
     SUCCEED();
 }

--- a/src/worker_group/thread_data.h
+++ b/src/worker_group/thread_data.h
@@ -37,13 +37,14 @@ typedef struct thread_data
     RowGroupsRange* file_row_groups_ranges;
 
     int n_group_columns;
-    int* group_columns_indices;
     ColumnDataType* group_columns_data_types;
 
     int n_select;
-    int* selects_indices;
     AggregateFunction* selects_aggregate_functions;
     ColumnDataType* select_columns_types;
+
+    int* columns_indices;
+    int* columns_non_repeating_mapping;
 } ThreadData;
 
 #endif //THREAD_DATA_H

--- a/src/worker_group/worker_group.h
+++ b/src/worker_group/worker_group.h
@@ -30,7 +30,7 @@ AggregateFunction worker_group_map_aggregate_function(Aggregate aggregate, Error
 
 RowGroupsRange** worker_group_get_row_group_ranges(int n_files, char** file_names, int num_threads, ErrorInfo* err);
 
-    void worker_group_get_columns_indices(const QueryRequest* request, int* column_indices, ErrorInfo* err);
+void worker_group_get_columns_indices(const QueryRequest* request, int* column_indices, ErrorInfo* err);
 
 void worker_group_free_row_group_ranges(RowGroupsRange** row_group_ranges, int count);
 

--- a/src/worker_group/worker_group.h
+++ b/src/worker_group/worker_group.h
@@ -16,14 +16,13 @@ extern "C" {
 #endif
 void worker_group_run_request(const QueryRequest* request, HashTable** request_hash_table, ErrorInfo* err);
 
-ColumnDataType* worker_group_get_columns_data_types(const int* indices, int indices_count, const char* filename,
-                                                    ErrorInfo* err);
+ColumnDataType* worker_group_get_columns_data_types(const int* indices, int indices_size, int indices_count,
+        int offset_from_start, const char* filename, ErrorInfo* err);
 
-ThreadData* worker_group_get_thread_data(const QueryRequest* request, int thread_index, int num_threads,
-                                         RowGroupsRange* row_groups_ranges, int* grouping_indices,
-                                         const int* select_indices,
-                                         ColumnDataType* group_columns_types, ColumnDataType* select_columns_types,
-                                         ErrorInfo* err);
+ThreadData* worker_group_get_thread_data(const QueryRequest* request, const int thread_index, const int num_threads,
+                                             RowGroupsRange* row_groups_ranges, int* columns_indices, int* columns_non_repeating_mappings,
+                                             ColumnDataType* group_columns_types, ColumnDataType* select_columns_types,
+                                             ErrorInfo* err);
 
 void worker_group_free_thread_data(ThreadData* thread_data);
 
@@ -31,12 +30,14 @@ AggregateFunction worker_group_map_aggregate_function(Aggregate aggregate, Error
 
 RowGroupsRange** worker_group_get_row_group_ranges(int n_files, char** file_names, int num_threads, ErrorInfo* err);
 
-void worker_group_get_columns_indices(const QueryRequest* request, int* grouping_indices, int* select_indices,
-                                      ErrorInfo* err);
+    void worker_group_get_columns_indices(const QueryRequest* request, int* column_indices, ErrorInfo* err);
 
 void worker_group_free_row_group_ranges(RowGroupsRange** row_group_ranges, int count);
 
 ColumnDataType worker_group_map_arrow_data_type(GArrowDataType* data_type, ErrorInfo* err);
+
+void worker_group_calculate_new_column_indices(int* new_column_indices, const gint* old_column_indices,
+                                         const int number_of_columns);
 
 #ifdef __cplusplus
 }

--- a/src/worker_group/workers/worker.h
+++ b/src/worker_group/workers/worker.h
@@ -28,8 +28,6 @@ char* construct_grouping_string(int n_group_columns, GArrowArray** grouping_arra
 HashTableValue get_hash_table_value(GArrowArray* select_array, int row_index, ColumnDataType select_columns_data_types,
                                     AggregateFunction aggregate_function, ErrorInfo* err);
 
-void worker_calculate_new_column_indices(int* new_column_indices, const gint* old_column_indices,
-                                         int number_of_columns);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
move calculations up to worker group level instead of repeating them for every worker
had to remove few free's cause im passing a poitner to thread data which i then later free after thread quits