### PR TITLE
fix freeing data that was moved to another hash table

### DIFF
--- a/src/hash_table/hash_table.c
+++ b/src/hash_table/hash_table.c
@@ -17,6 +17,13 @@ unsigned int hash(const char* string, const int table_size) {
       return hash_value % table_size;
 }
 
+void hash_table_free_entry(HashTableEntry* value) {
+      free(value->key);
+      free(value->values);
+      free(value);
+      value = NULL;
+}
+
 HashTable* hash_table_create(const int size, ErrorInfo* err) {
 
       if (err == NULL) {
@@ -352,7 +359,7 @@ void hash_table_combine_hash_tables(HashTable* destination, HashTable* source, E
                   entry = next;
 
                   if (to_be_freed != NULL) {
-                        free(to_be_freed);
+                        hash_table_free_entry(to_be_freed);
                   }
             }
       }

--- a/src/hash_table/hash_table.c
+++ b/src/hash_table/hash_table.c
@@ -222,7 +222,7 @@ void hash_table_combine_entries(HashTableEntry* entry1, const HashTableEntry* en
             return;
       }
 
-      if(entry1->n_values > entry2->n_values) {
+      if(entry1->n_values != entry2->n_values) {
             LOG_INTERNAL_ERR("Failed to combine hash table entries: Entries have different number of values");
             SET_ERR(err, INTERNAL_ERROR, "Failed to combine hash table entries",
                   "Entries have different number of values");

--- a/src/hash_table/hash_table.h
+++ b/src/hash_table/hash_table.h
@@ -38,6 +38,6 @@ void hash_table_print(const HashTable* ht);
 void hash_table_combine_entries(HashTableEntry* entry1, const HashTableEntry* entry2, ErrorInfo* err);
 HashTableValue hash_table_update_value(HashTableValue current_value, HashTableValue incoming_value, ErrorInfo* err);
 void hash_table_combine_table_with_response(HashTable* ht, const QueryResponse* query_response, ErrorInfo* err);
-void hash_table_combine_hash_tables(HashTable* destination, const HashTable* source, ErrorInfo* err);
+void hash_table_combine_hash_tables(HashTable* destination, HashTable* source, ErrorInfo* err);
 
 #endif //HASH_TABLE_H

--- a/src/hash_table/hash_table.h
+++ b/src/hash_table/hash_table.h
@@ -39,5 +39,6 @@ void hash_table_combine_entries(HashTableEntry* entry1, const HashTableEntry* en
 HashTableValue hash_table_update_value(HashTableValue current_value, HashTableValue incoming_value, ErrorInfo* err);
 void hash_table_combine_table_with_response(HashTable* ht, const QueryResponse* query_response, ErrorInfo* err);
 void hash_table_combine_hash_tables(HashTable* destination, HashTable* source, ErrorInfo* err);
+void hash_table_free_entry(HashTableEntry* value) ;
 
 #endif //HASH_TABLE_H

--- a/src/worker_group/worker_group.c
+++ b/src/worker_group/worker_group.c
@@ -184,7 +184,7 @@ void worker_group_run_request(const QueryRequest* request, HashTable** request_h
                 SET_ERR(err, INTERNAL_ERROR, "Failed to run worker group", "Failed to combine hash tables");
                 // TODO handle exit?? or we need to wait for other threads anyway (now)
             }
-            hash_table_free(thread_ht);
+            free(thread_ht);
         }
     }
 

--- a/src/worker_group/workers/worker.c
+++ b/src/worker_group/workers/worker.c
@@ -270,12 +270,6 @@ void compute_file(const int index_of_the_file, const ThreadData* data, HashTable
             }
 
             const guint number_of_rows = garrow_chunked_array_get_n_rows(grouping_chunked_arrays[chunk_index]);
-            if (error != NULL)
-            {
-                report_g_error(error, err, "Failed to retrieve number of rows");
-                // TODO free allocated data
-                return;
-            }
 
             for (int row_index = 0; row_index < number_of_rows; row_index++)
             {

--- a/src/worker_group/workers/worker.c
+++ b/src/worker_group/workers/worker.c
@@ -269,7 +269,7 @@ void compute_file(const int index_of_the_file, const ThreadData* data, HashTable
                 select_arrays[select] = garrow_chunked_array_get_chunk(select_chunked_arrays[select], chunk_index);
             }
 
-            const gint number_of_rows = (gint)garrow_array_count(grouping_arrays[0], NULL, &error);
+            const guint number_of_rows = garrow_chunked_array_get_n_rows(grouping_chunked_arrays[chunk_index]);
             if (error != NULL)
             {
                 report_g_error(error, err, "Failed to retrieve number of rows");


### PR DESCRIPTION
the problem was i was freeing up data when it was used on cobime hash tables the apporach should be to either copy the data and add it to combined table or not remove it and remove it only after we are done im using right now the second approach with removing the data